### PR TITLE
Add missing class="hljs" to pre tag

### DIFF
--- a/Sources/HighlightJSPublishPlugin/HighlightJSPublishPlugin.swift
+++ b/Sources/HighlightJSPublishPlugin/HighlightJSPublishPlugin.swift
@@ -31,7 +31,7 @@ public extension Modifier {
 
             let highlighted = highlighter.highlight(String(code),
                                                     as: String(language))
-            return "<pre data-language=\"\(highlighted.language)\"><code>\(highlighted.value)\n</code></pre>"
+            return "<pre data-language=\"\(highlighted.language)\" class=\"hljs\"><code>\(highlighted.value)\n</code></pre>"
         }
     }
 }


### PR DESCRIPTION
[Highlight.js styles](https://github.com/highlightjs/highlight.js/tree/main/src/styles) have a root `.hljs` class that contains root text color and background color.

This PR adds that class to the outputted HTML and fixes background styles not applying.

Easiest to see when using a dark theme: before the background was white (or other inherited site background) but after this addition the code block uses the background color of the given style.

Before:
<img width="920" alt="before" src="https://user-images.githubusercontent.com/6566702/161435918-e88b9d11-a023-42de-80f6-3390a05f8baa.png">

After:
<img width="902" alt="after" src="https://user-images.githubusercontent.com/6566702/161435934-1e0a6759-2e1a-45d4-b68d-3366d1556e0a.png">

I'm using Atom One Dark styles there.