### PR TITLE
Compatibility with latest Publish version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.swiftpm
 /*.xcodeproj
 /.build
 /Packages

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "CollectionConcurrencyKit",
+        "repositoryURL": "https://github.com/johnsundell/collectionConcurrencyKit.git",
+        "state": {
+          "branch": null,
+          "revision": "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+          "version": "0.2.0"
+        }
+      },
+      {
         "package": "Files",
         "repositoryURL": "https://github.com/johnsundell/files.git",
         "state": {
@@ -33,17 +42,17 @@
         "repositoryURL": "https://github.com/johnsundell/plot.git",
         "state": {
           "branch": null,
-          "revision": "ccabb2674ca0d9ccfabd5e7c0c44c6cca6c827fb",
-          "version": "0.5.0"
+          "revision": "b358860fe565eb53e98b1f5807eb5939c8124547",
+          "version": "0.11.0"
         }
       },
       {
         "package": "Publish",
         "repositoryURL": "https://github.com/johnsundell/publish.git",
         "state": {
-          "branch": null,
-          "revision": "ff50bdcc154efd89a16eb7006182e7d70ef38aff",
-          "version": "0.4.0"
+          "branch": "swift-concurrency",
+          "revision": "add68b550b9d68ae2c5706d5d451c3af4b84b5fe",
+          "version": null
         }
       },
       {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/johnsundell/sweep.git",
         "state": {
           "branch": null,
-          "revision": "d357d12c9558e51f037bf2f956d5cf6c73dc0d44",
-          "version": "0.3.0"
+          "revision": "801c2878e4c6c5baf32fe132e1f3f3af6f9fd1b0",
+          "version": "0.4.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/johnsundell/files.git",
         "state": {
           "branch": null,
-          "revision": "22fe84797d499ffca911ccd896b34efaf06a50b9",
-          "version": "4.1.1"
+          "revision": "d273b5b7025d386feef79ef6bad7de762e106eaf",
+          "version": "4.2.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/johnsundell/ink.git",
         "state": {
           "branch": null,
-          "revision": "a9a1a0190aaacc9058a2bfbdcd831785eac26f43",
-          "version": "0.3.0"
+          "revision": "77c3d8953374a9cf5418ef0bd7108524999de85a",
+          "version": "0.5.1"
         }
       },
       {
@@ -50,9 +50,9 @@
         "package": "Publish",
         "repositoryURL": "https://github.com/johnsundell/publish.git",
         "state": {
-          "branch": "swift-concurrency",
-          "revision": "add68b550b9d68ae2c5706d5d451c3af4b84b5fe",
-          "version": null
+          "branch": null,
+          "revision": "1c8ad00d39c985cb5d497153241a2f1b654e0d40",
+          "version": "0.9.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/johnsundell/publish.git",
-            branch: "swift-concurrency"
+            from: "0.9.0"
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "HighlightJSPublishPlugin",
+    platforms: [.macOS(.v12)],
     products: [
         .library(
             name: "HighlightJSPublishPlugin",
@@ -14,13 +15,13 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/johnsundell/publish.git",
-            from: "0.3.0"
+            branch: "swift-concurrency"
         ),
     ],
     targets: [
         .target(
             name: "HighlightJSPublishPlugin",
-            dependencies: ["HighlightJS", "Publish"]
+            dependencies: ["HighlightJS", .product(name: "Publish", package: "publish")]
         ),
         .testTarget(
             name: "HighlightJSPublishPluginTests",


### PR DESCRIPTION
Hi,
Thank you for this wonderful plugin! 

This PR makes the plugin compatible with the [latest version of Publish](https://github.com/JohnSundell/Publish/releases/tag/0.9.0).

I've already tried it with @wwdcnotes, and it works great!