### PR TITLE
Update Readme to run on Xcode 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add HighlightJSPublishPlugin to your package.
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/alex-ross/highlightjspublishplugin", from: "1.0.0")
+        .package(name: "HighlightJSPublishPlugin", url: "https://github.com/alex-ross/highlightjspublishplugin", from: "1.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Xcode would refuse to build without this addition. I am not sure if it is specific to v13. 